### PR TITLE
Fix `get_submodules` No such file or directory error

### DIFF
--- a/generate_db.py
+++ b/generate_db.py
@@ -29,7 +29,15 @@ def generate_db(log_output, database_path):
     return last_commit
 
 def get_submodules(source_path):
-    l = subprocess.Popen(f"git -C {source_path}" + r" config -z --file .gitmodules --get-regexp submodule\..*\.path", stdout=subprocess.PIPE).stdout.read().split(b"\0")
+    args = [
+        "git",
+        "-C", source_path,
+        "config", "-z",
+        "--file", ".gitmodules",
+        "--get-regexp", r"submodule\..*\.path",
+    ]
+
+    l = subprocess.Popen(args, stdout=subprocess.PIPE).stdout.read().split(b"\0")
     return [pathlib.Path(os.fsdecode(i.splitlines()[1])) for i in l if len(i)]
 
 def generate_recursive(source_path, source_path_parent, dest_dir_parent):


### PR DESCRIPTION
I've been consistently getting this error at `generate_db.py:32`:

```shell
$ python generate_db.py /redacted/home/repo_name
/redacted/home/repo_name
Database generated at "/redacted/home/Git-Heat-Map/repos/repo_name/repo_name.db"
Traceback (most recent call last):
  File "/redacted/home/Git-Heat-Map/generate_db.py", line 86, in <module>
    main()
  File "/redacted/home/Git-Heat-Map/generate_db.py", line 83, in main
    generate_recursive(source_path, source_path.parent, repos_dir)
  File "/redacted/home/Git-Heat-Map/generate_db.py", line 64, in generate_recursive
    submodule_paths = get_submodules(source_path)
  File "/redacted/home/Git-Heat-Map/generate_db.py", line 33, in get_submodules
    l = subprocess.Popen(f"git -C {source_path}" + r" config -z --file .gitmodules --get-regexp submodule\..*\.path", stdout=subprocess.PIPE).stdout.read().split(b"\0")
  File "/redacted/home/.pyenv/versions/3.10.6/lib/python3.10/subprocess.py", line 969, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/redacted/home/.pyenv/versions/3.10.6/lib/python3.10/subprocess.py", line 1845, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'git -C /redacted/home/repo_name config -z --file .gitmodules --get-regexp submodule\\..*\\.path'
```

This change fixed my problem. I was able to create the database in a repo without submodules and a repo with submodules:
<img width="1123" height="156" alt="image" src="https://github.com/user-attachments/assets/2f294afc-fbda-4760-a162-19afae2ed9cb" />

I'm on MacOS Sequoia 15.6, arm64, and I'm using `pyenv`, `pyenv-virtualenv`. I was getting the same issue both on python 3.13.2 and python 3.10.6

([this](https://changelog.com/friends/107) podcast brought me here)
